### PR TITLE
Fix WePayError.

### DIFF
--- a/wepay/exceptions.py
+++ b/wepay/exceptions.py
@@ -3,4 +3,11 @@ class WePayError(Exception):
     Raised when an error comes back in the API response from WePay.
     """
     def __init__(self, error_type, error_code, message):
-        Exception.__init__(self, error_type, error_code, message)
+        super(WePayError, self).__init__(message)
+        self.error_type = error_type
+        self.error_code = error_code
+
+    def __repr__(self):
+        return "<%s:type=%r,code=%r,msg=%r>" % (
+            self.__class__.__name__,
+            self.error_type, self.error_code, self.message)


### PR DESCRIPTION
Python's base class `Exception` takes only a single parameter as
"message":

```
>>> Exception("foo").message
'foo'
```

but if you pass more arguments to the `Exception` constructor, it
doesn't populate the `message` field:

```
>>> Exception("foo", "bar", "quux").message
''
```

Here's the corresponding Python source code:

``` c
static int
BaseException_init(PyBaseExceptionObject *self, PyObject *args, PyObject *kwds)
{
    if (!_PyArg_NoKeywords(Py_TYPE(self)->tp_name, kwds))
        return -1;

    Py_DECREF(self->args);
    self->args = args;
    Py_INCREF(self->args);

    if (PyTuple_GET_SIZE(self->args) == 1) {
        Py_CLEAR(self->message);
        self->message = PyTuple_GET_ITEM(self->args, 0);
        Py_INCREF(self->message);
    }
    return 0;
}
```

You can see it sets `self->message` to `args[0]` if the size of the
tuple is 1. Otherwise, it skips setting `self->message`.
