### PR TITLE
Delay importing requests so we don't get `ImportError` when running setup

### DIFF
--- a/wepay/api.py
+++ b/wepay/api.py
@@ -1,4 +1,3 @@
-import requests
 import urllib
 import json
 from wepay.exceptions import WePayError
@@ -17,6 +16,8 @@ class WePay(object):
         :param str access_token: The access token associated with your
             application.
         """
+        import requests
+        self.requests = requests
         self.access_token = access_token
         self.api_version = api_version
 
@@ -53,7 +54,7 @@ class WePay(object):
         if params:
             params = json.dumps(params)
 
-        response = requests.post(
+        response = self.requests.post(
             url, data=params, headers=headers, timeout=30)
         response_json = response.json()
         if 400 <= response.status_code <= 599:


### PR DESCRIPTION
Currently (wepay 0.2.1), `pip install wepay` fails with the following message:

```
 $ pip install wepay
Downloading/unpacking wepay
  Downloading wepay-0.2.1.tar.gz
  Running setup.py egg_info for package wepay
    Traceback (most recent call last):
      File "<string>", line 16, in <module>
      File "/tmp/env/build/wepay/setup.py", line 2, in <module>
        import wepay
      File "wepay/__init__.py", line 1, in <module>
        from api import WePay
      File "wepay/api.py", line 1, in <module>
        import requests
    ImportError: No module named requests
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 16, in <module>

  File "/tmp/env/build/wepay/setup.py", line 2, in <module>

    import wepay

  File "wepay/__init__.py", line 1, in <module>

    from api import WePay

  File "wepay/api.py", line 1, in <module>

    import requests

ImportError: No module named requests

----------------------------------------
Command python setup.py egg_info failed with error code 1 in /tmp/env/build/wepay
Storing complete log in /home/fresh/.pip/pip.log
```

This is because:
`setup.py` needs to access `wepay.VERSION`, and the `wepay` module imports
`wepay.api` which depends on `requests`, but at the time setup is
running, `requests` library has not been installed (will be installed as
part of `install_requires` specified in setup.py). This fix breaks the
circular import by delaying importing `requests` until a `WePay` object
is instantiated.

**Alternatively**, you can move `VERSION` in `setup.py`, without changing anything else at all. However, since `VERSION` has been in the API as `wepay.VERSION`, I opted for the non-API-breaking route for the fix.
