### PR TITLE
Fix import issue during setup

### DIFF
--- a/wepay/__init__.py
+++ b/wepay/__init__.py
@@ -1,4 +1,4 @@
-from api import WePay
+from wepay.api import WePay
 
 # Major, minor, revision
 VERSION = (0, 3, 0)


### PR DESCRIPTION
WePay SDK fails to install with Python 3:

```
# python3 setup.py install
Traceback (most recent call last):
  File "setup.py", line 2, in <module>
    import wepay
  File "/root/Python-SDK/wepay/__init__.py", line 1, in <module>
    from api import WePay
ImportError: No module named 'api'
```

This change should fix this issue.