### PR TITLE
System 2.7.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from setuptools import setup
 import wepay
 import os.path
+import sys
 
 long_description = open('README.rst').read() if os.path.isfile('README.rst') else 'A Python SDK for our WePay API'
 
@@ -9,6 +10,10 @@ version_str = '%s.%s.%s' % (
     wepay.VERSION[1],
     wepay.VERSION[2]
 )
+
+if not (sys.version_info[0] == 2 and sys.version_info[1] == 7):
+    print("Please use Python 2.7.x")
+    sys.exit(1) # return non-zero value for failure
 
 setup(
     name='wepay',
@@ -27,7 +32,8 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7 :: Only'
     ],
     install_requires=['requests==2.2.1']
+
 )


### PR DESCRIPTION
This has been tested on Python 2.7. setup.py enforces this by quitting if the system is not on Python 2.7.x