### PR TITLE
Added error handling to `api.get_token`

### DIFF
--- a/wepay/api.py
+++ b/wepay/api.py
@@ -122,5 +122,13 @@ class WePay(object):
         if callback_uri:
             params.update({'callback_uri': callback_uri})
         response = self.call('/oauth2/token', params)
+      
+        # The call to /oauth2/token should return an access_token
+        # if the access_token was not returned, then an error occured
+        # we need to raise this error, 
+        # otherwise this will die when trying to use the 'acess_token' field
+        if 'access_token' not in response:
+            raise WePayError(response['error'], response['error_code'], response['error_description'])
+
         self.access_token = response['access_token']
         return response


### PR DESCRIPTION
`get_token` would make a request to `/oauth2/token` and then assume that the response from that call was valid.  If the response was invalid, trying to access data from the response object would cause a `KeyError,` which isn't actually the cause of the problem.

Added a simple check to raise a `WePayError` if the request failed.  The error includes the WePay API error code and error message.