### PR TITLE
Added risk header support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.3.3 Python SDK (2017-01-19)
+
+## Bug Fixes
+* **Version:** Updated version number to 0.3.3
+
+## Breaking Changes
+* **risk_token, client_ip:** Added optional risk_token and client_ip params to the API call function.
+
 # 0.3.2 Python SDK (2015-11-13)
 
 ## Bug fixes

--- a/README.md
+++ b/README.md
@@ -89,6 +89,20 @@ Redirect them to their account page to see it:
 
     web.redirect(create_response['account_uri'])
 
+WePay Risk Headers
+-----
+
+You can supply WePay with risk-related information on every API call by passing the WePay-Risk-Token and Client-IP values to the `call` function:
+
+```
+wepay.call('/account/modify', {
+    'account_id': create_response['account_id'],
+    'image_uri': 'http://www.placekitten.com/500/500'
+}, risk_token='123e4567-e89b-12d3-a456-426655440000', client_ip='100.166.99.123')
+```
+
+Detailed information regarding the Risk Headers can be found at the [WePay API Documentation](https://developer.wepay.com/reference/risk_headers).
+
 Try it!
 -----
 

--- a/wepay/__init__.py
+++ b/wepay/__init__.py
@@ -1,4 +1,4 @@
 from wepay.api import WePay
 
 # Major, minor, revision
-VERSION = (0, 3, 2)
+VERSION = (0, 3, 3)

--- a/wepay/api.py
+++ b/wepay/api.py
@@ -31,7 +31,7 @@ class WePay(object):
             self.api_endpoint = "https://stage.wepayapi.com/v2"
             self.browser_endpoint = "https://stage.wepay.com/v2"
 
-    def call(self, uri, params=None, token=None):
+    def call(self, uri, params=None, token=None, risk_token=None, client_ip=None):
         """
         Calls wepay.com/v2/``uri`` with ``params`` and returns the JSON
         response as a python dict. The optional token parameter will override
@@ -41,6 +41,8 @@ class WePay(object):
         :param dict params: The parameters to pass to the URI.
         :param str token: Optional override for this ``WePay`` object's access
             token.
+        :param str risk_token: Optional WePay-Risk-Token for this API call.
+        :param str client_ip: Optional Client-IP for this API call.
         """
 
         headers = {'Content-Type': 'application/json',
@@ -53,6 +55,12 @@ class WePay(object):
 
         if self.api_version:
             headers['Api-Version'] = self.api_version
+
+        if risk_token:
+            headers['WePay-Risk-Token'] = risk_token
+
+        if client_ip:
+            headers['Client-IP'] = client_ip
 
         if params:
             params = json.dumps(params)


### PR DESCRIPTION
WePay-Risk-Token and Client-IP are now available headers on all API calls (see: https://developer.wepay.com/reference/risk_headers). This PR adds support for these optional headers and updates the README.